### PR TITLE
chore: modify hub metadata to store banner and thumbnail image

### DIFF
--- a/hub/src/contract.rs
+++ b/hub/src/contract.rs
@@ -97,7 +97,8 @@ mod tests {
                 url: "discord link here".to_string(),
             }],
             creator: CREATOR.to_string(),
-            image_url: "image link here".to_string(),
+            thumbnail_image_url: "image link here".to_string(),
+            banner_image_url: "image link here".to_string(),
         };
         //no owner specified in the instantiation message
         let mut msg = json!({
@@ -136,7 +137,8 @@ mod tests {
                 url: "discord link here".to_string(),
             }],
             creator: CREATOR.to_string(),
-            image_url: "image link here".to_string(),
+            thumbnail_image_url: "image link here".to_string(),
+            banner_image_url: "image link here".to_string(),
         };
         let mut msg = json!({
             "ownable": {

--- a/hub/src/state.rs
+++ b/hub/src/state.rs
@@ -44,7 +44,8 @@ pub struct HubMetadata {
     pub tags: Vec<String>,
     pub social_links: Vec<SocialLinks>,
     pub creator: String,
-    pub image_url: String,
+    pub thumbnail_image_url: String,
+    pub banner_image_url: String,
 }
 
 pub struct HubModules<'a, T>


### PR DESCRIPTION
This PR satisfies the design allowing for hubs to have 2 separate images